### PR TITLE
Django 4.2 Upgrade

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+Version 0.9.1, 15th Feb 2025
+--------------------------
+
+Upgrade for Django 4.2 compatibility
+
 Version 0.9, 15th May 2013
 --------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -34,9 +34,9 @@ the placeholder ``comments/list.html`` template will already be replaced by a th
 
 Make sure django.contrib.comments_ is configured in ``urls.py``::
 
-    urlpatterns += patterns('',
-        url(r'^articles/comments/', include('django.contrib.comments.urls')),
-    )
+    urlpatterns += [
+        re_path(r'^articles/comments/', include('django_comments.urls')),
+    ]
 
 Provide a template that displays the comments for the ``object`` (e.g. article or blog entry)::
 

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ the placeholder ``comments/list.html`` template will already be replaced by a th
 Make sure django.contrib.comments_ is configured in ``urls.py``::
 
     urlpatterns += [
-        re_path(r'^articles/comments/', include('django_comments.urls')),
+        re_path(r'^articles/comments/', include('django.contrib.comments.urls')),
     ]
 
 Provide a template that displays the comments for the ``object`` (e.g. article or blog entry)::

--- a/examples/example/urls.py
+++ b/examples/example/urls.py
@@ -1,13 +1,13 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import include
+from django.urls import re_path
 from django.contrib import admin
 
 # Enable the admin
 admin.autodiscover()
 
-urlpatterns = patterns('',
-    url(r'^admin/', include(admin.site.urls)),
-    url(r'^comments/', include('django.contrib.comments.urls')),
-
-    url(r'^$', 'core.views.home', name='homepage'),
-    url(r'^message/(?P<id>.+)$', 'core.views.message', name='message_detail'),
-)
+urlpatterns = [
+    re_path(r'^admin/', include(admin.site.urls)),
+    re_path(r'^comments/', include('django.contrib.comments.urls')),
+    re_path(r'^$', 'core.views.home', name='homepage'),
+    re_path(r'^message/(?P<id>.+)$', 'core.views.message', name='message_detail'),
+]

--- a/threadedcomments/__init__.py
+++ b/threadedcomments/__init__.py
@@ -5,7 +5,7 @@ from threadedcomments.models import ThreadedComment
 from threadedcomments.forms import ThreadedCommentForm
 
 # following PEP 386
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 
 def get_model():
     return ThreadedComment

--- a/threadedcomments/admin.py
+++ b/threadedcomments/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.contrib.comments.admin import CommentsAdmin
 
 from threadedcomments.models import ThreadedComment

--- a/threadedcomments/forms.py
+++ b/threadedcomments/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.contrib.comments.forms import CommentForm
 from django.conf import settings
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from threadedcomments.models import ThreadedComment
 

--- a/threadedcomments/models.py
+++ b/threadedcomments/models.py
@@ -2,7 +2,7 @@ from django.db import models
 from django.contrib.comments.models import Comment
 from django.contrib.comments.managers import CommentManager
 from django.conf import settings
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 PATH_SEPARATOR = getattr(settings, 'COMMENT_PATH_SEPARATOR', '/')
 PATH_DIGITS = getattr(settings, 'COMMENT_PATH_DIGITS', 10)


### PR DESCRIPTION
Compatibility fixes for Django 4.2

## Django 4.0.10
* [Django 4.0 deprecations](https://docs.djangoproject.com/en/5.0/internals/deprecation/#deprecation-removed-in-4-0):
* See the [Django 3.0 release notes](https://docs.djangoproject.com/en/5.0/releases/3.0/#deprecated-features-3-0) for more details on these changes.

- [x] **django.utils.encoding.force_text()** and **smart_text()** will be removed.  The aliases are  force_str() and smart_str().
- [x] **django.utils.http.urlquote()**, **urlquote_plus()**, **urlunquote()**, and **urlunquote_plus()** will be removed.
- [x] **django.utils.translation.ugettext()**, **ugettext_lazy()**, **ugettext_noop()**, **ungettext()**, and **ungettext_lazy()** will be removed.
- [x] **django.views.i18n.set_language()** will no longer set the user language in **request.session** (key **django.utils.translation.LANGUAGE_SESSION_KEY**). 
- [x] **alias=None** will be required in the signature of **django.db.models.Expression.get_group_by_cols()** subclasses.
- [x] **django.utils.text.unescape_entities()** will be removed.
- [x] **django.utils.http.is_safe_url()** will be removed.

* See the [Django 3.1 release notes](https://docs.djangoproject.com/en/5.0/releases/3.1/#deprecated-features-3-1) for more details on these changes.
- [x] **The PASSWORD_RESET_TIMEOUT_DAYS** setting will be removed.
- [x] The undocumented usage of the **isnull** lookup with non-boolean values as the right-hand side will no longer be allowed.
- [x] The **django.db.models.query_utils.InvalidQuery** exception class will be removed.
- [x] The **django-admin.py** entry point will be removed.
- [x] Support for the pre-Django 3.1 encoding format of cookies values used by **django.contrib.messages.storage.cookie.CookieStorage** will be removed.
- [x] The **providing_args** argument for **django.dispatch.Signal** will be removed.
- [x] The **length** argument for **django.utils.crypto.get_random_string()** will be required.
- [x] The model **NullBooleanField** will be removed. A stub field will remain for compatibility with historical migrations. 
- [x] The model **django.contrib.postgres.fields.JSONField** will be removed. A stub field will remain for compatibility with historical migrations.
- [x] **django.contrib.postgres.forms.JSONField**, **django.contrib.postgres.fields.jsonb.KeyTransform**, and **django.contrib.postgres.fields.jsonb.KeyTextTransform** will be removed.
- [x] The **DEFAULT_HASHING_ALGORITHM** transitional setting will be removed.
- [x] Support for passing raw column aliases to **QuerySet.order_by()** will be removed.
- [x] **django.conf.urls.url()** will be removed.  It's an alias of **django.urls.re_path()**.
- [x] The **get_response** argument for **django.utils.deprecation.MiddlewareMixin.__init__()** will be required and won’t accept **None**.
- [x] The **list** message for **ModelMultipleChoiceField** will be removed.
- [x] The **HttpRequest.is_ajax()** method will be removed.
- [x] The **{% ifequal %}** and **{% ifnotequal %}** template tags will be removed.

### pre-Django 3.1 SHA-1
- [x] Support for the pre-Django 3.1 password reset tokens in the admin site (that use the SHA-1 hashing algorithm) will be removed.
- [x] Support for the pre-Django 3.1 encoding format of sessions will be removed.
- [x] Support for the pre-Django 3.1 **django.core.signing.Signer** signatures (encoded with the SHA-1 algorithm) will be removed.
- [x] Support for the pre-Django 3.1 **django.core.signing.dumps()** signatures (encoded with the SHA-1 algorithm) in **django.core.signing.loads()** will be removed.
- [x] Support for the pre-Django 3.1 user sessions (that use the SHA-1 algorithm) will be removed.

## Django 4.1.13
See the [Django 3.2 release notes](https://docs.djangoproject.com/en/5.0/releases/3.2/#deprecated-features-3-2) for more details on these changes.

- [x] Support for assigning objects which don’t support creating deep copies with **copy.deepcopy()** to class attributes in **TestCase.setUpTestData()** will be removed.
- [x] The **whitelist** argument and **domain_whitelist** attribute of **django.core.validators.EmailValidator** will be removed.
- [x] **TransactionTestCase.assertQuerysetEqual()** will no longer automatically call **repr()** on a queryset when compared to string values.
- [x] Support for the pre-Django 3.2 format of messages used by **django.contrib.messages.storage.cookie.CookieStorage** will be removed.
- [x] **BaseCommand.requires_system_checks** won’t support boolean values. Use '__all__' instead of True, and [] (an empty list) instead of False.
- [x] **django.core.cache.backends.memcached.MemcachedCache** will be removed.
- [x] The **default_app_config** module variable will be removed. 
