### PR TITLE
Unit test fixes & Django 4.2 Upgrade for 0.5.6 branch. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .tox/
 *.pyc
 *.egg-info/
+.python-version

--- a/docs/tutorial.txt
+++ b/docs/tutorial.txt
@@ -127,13 +127,16 @@ your ``ROOT_URLCONF``) you include 'threadedcomments.urls'.
 
 In the end, your ``urls.py`` file may look something like this::
 
-    from django.conf.urls.defaults import *
+```python
+    from django.conf.urls import include
+    from django.urls import re_path
 
-    urlpatterns = patterns('',
-        (r'^blog/', include('blog.urls')),
-        (r'^admin/', include('django.contrib.admin.urls')),
-        (r'^threadedcomments/', include('threadedcomments.urls')),
-    )
+    urlpatterns = [
+        re_path(r'^blog/', include('blog.urls')),
+        re_path(r'^admin/', include('django.contrib.admin.urls')),
+        re_path(r'^threadedcomments/', include('threadedcomments.urls')),
+    ]
+```
 
 Make sure to run ``python manage.py syncdb`` to finish off this step.
 

--- a/examples/example2/urls.py
+++ b/examples/example2/urls.py
@@ -1,16 +1,26 @@
-from django.conf.urls.defaults import patterns, url, include
-from voting.views import xmlhttprequest_vote_on_object
-from threadedcomments.models import ThreadedComment
 from django.conf import settings
+from django.conf.urls import include
+from django.urls import re_path
 
-urlpatterns = patterns('',
-    url(r'^register/$', 'exampleblog.views.register', name="exampleblog_register"),
-    url(r'^login/$', 'exampleblog.views.auth_login', name="exampleblog_login"),
-    url(r'^check_exists/$', 'exampleblog.views.check_exists', name="exampleblog_checkexists"),
-    url(r'^blog/$', 'exampleblog.views.latest_post', name="exampleblog_latest"),
-    url(r'^vote/(?P<object_id>\d+)/(?P<direction>up|down|clear)vote/$', xmlhttprequest_vote_on_object, { 'model' : ThreadedComment }, name="vote_on_object"),
-    url(r'^partial/(?P<comment_id>\d+)/$', 'exampleblog.views.comment_partial', name="comment_partial"),
-    (r'^threadedcomments/', include('threadedcomments.urls')),
-    (r'^admin/', include('django.contrib.admin.urls')),
-    (r'^site_media/(?P<path>.*)$', 'django.views.static.serve', {'document_root': settings.MEDIA_ROOT}),
+from threadedcomments.models import ThreadedComment
+from voting.views import xmlhttprequest_vote_on_object
+
+from exampleblog.views import (
+    auth_login,
+    check_exists,
+    comment_partial,
+    latest_post,
+    register,
 )
+
+urlpatterns = [
+    re_path(r'^register/$', register, name="exampleblog_register"),
+    re_path(r'^login/$', auth_login, name="exampleblog_login"),
+    re_path(r'^check_exists/$', check_exists, name="exampleblog_checkexists"),
+    re_path(r'^blog/$', latest_post, name="exampleblog_latest"),
+    re_path(r'^vote/(?P<object_id>\d+)/(?P<direction>up|down|clear)vote/$', xmlhttprequest_vote_on_object, { 'model' : ThreadedComment }, name="vote_on_object"),
+    re_path(r'^partial/(?P<comment_id>\d+)/$', comment_partial, name="comment_partial"),
+    re_path(r'^threadedcomments/', include('threadedcomments.urls')),
+    re_path(r'^admin/', include('django.contrib.admin.urls')),
+    re_path(r'^site_media/(?P<path>.*)$', 'django.views.static.serve', {'document_root': settings.MEDIA_ROOT}),
+]

--- a/examples/tut1/urls.py
+++ b/examples/tut1/urls.py
@@ -1,7 +1,10 @@
-from django.conf.urls.defaults import patterns, include
+from django.conf.urls import include
+from django.urls import re_path
 
-urlpatterns = patterns('',
-     (r'^blog/$', 'blog.views.latest_post'),
-     (r'^admin/', include('django.contrib.admin.urls')),
-     (r'^threadedcomments/', include('threadedcomments.urls')),
-)
+from blog.views import latest_post
+
+urlpatterns = [
+     re_path(r'^blog/$', latest_post),
+     re_path(r'^admin/', include('django.contrib.admin.urls')),
+     re_path(r'^threadedcomments/', include('threadedcomments.urls')),
+]

--- a/run_tests.py
+++ b/run_tests.py
@@ -10,6 +10,7 @@ if not settings.configured:
                 'ENGINE': 'django.db.backends.sqlite3',
             }
         },
+        SECRET_KEY='dummy-key-for-tests',
         TEMPLATE_LOADERS=(
             'django.template.loaders.app_directories.Loader',
         ),

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='django-threadedcomments',
-    version='0.5.5',
+    version='0.5.6',
     description='A simple yet flexible threaded commenting system.',
     author='Eric Florenzano',
     author_email='floguy@gmail.com',

--- a/threadedcomments/forms.py
+++ b/threadedcomments/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 from threadedcomments.models import DEFAULT_MAX_COMMENT_LENGTH
 from threadedcomments.models import FreeThreadedComment, ThreadedComment
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 class ThreadedCommentForm(forms.ModelForm):
     """

--- a/threadedcomments/models.py
+++ b/threadedcomments/models.py
@@ -6,7 +6,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes.fields import GenericForeignKey
 from datetime import datetime
 from django.db.models import Q
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.conf import settings
 from django.utils.encoding import force_str
 

--- a/threadedcomments/models.py
+++ b/threadedcomments/models.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from django.db.models import Q
 from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 DEFAULT_MAX_COMMENT_LENGTH = getattr(
     settings,
@@ -292,7 +292,7 @@ class ThreadedComment(models.Model):
             'is_public': self.is_public,
             'is_approved': self.is_approved,
             'ip_address': self.ip_address,
-            'markup': force_text(markup),
+            'markup': force_str(markup),
         }
         if show_dates:
             to_return['date_submitted'] = self.date_submitted
@@ -430,7 +430,7 @@ class FreeThreadedComment(models.Model):
             'is_public': self.is_public,
             'is_approved': self.is_approved,
             'ip_address': self.ip_address,
-            'markup': force_text(markup),
+            'markup': force_str(markup),
         }
         if show_dates:
             to_return['date_submitted'] = self.date_submitted

--- a/threadedcomments/templatetags/threadedcommentstags.py
+++ b/threadedcomments/templatetags/threadedcommentstags.py
@@ -4,7 +4,7 @@ import six
 from django import template
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.safestring import mark_safe
 from threadedcomments.models import ThreadedComment, FreeThreadedComment
 from threadedcomments.forms import ThreadedCommentForm, FreeThreadedCommentForm
@@ -168,12 +168,12 @@ def auto_transform_markup(comment):
             from django.contrib.markup.templatetags.markup import restructuredtext
             return restructuredtext(comment.comment)
 #        elif comment.markup == HTML:
-#            return mark_safe(force_text(comment.comment))
+#            return mark_safe(force_str(comment.comment))
         elif comment.markup == PLAINTEXT:
             return escape(comment.comment)
     except ImportError:
         # Not marking safe, in case tag fails and users input malicious code.
-        return force_text(comment.comment)
+        return force_str(comment.comment)
 
 def do_auto_transform_markup(parser, token):
     try:

--- a/threadedcomments/tests/threadedcomments_urls.py
+++ b/threadedcomments/tests/threadedcomments_urls.py
@@ -1,9 +1,7 @@
-try:
-    from django.conf.urls.defaults import *
-except ImportError:
-    from django.conf.urls import *
+from django.conf.urls import include
+from django.urls import re_path
 
 
-urlpatterns = patterns("",
-    url(r"", include("threadedcomments.urls")),
-)
+urlpatterns = [
+    re_path(r"", include("threadedcomments.urls")),
+]

--- a/threadedcomments/tests/views_tests.py
+++ b/threadedcomments/tests/views_tests.py
@@ -23,11 +23,6 @@ __all__ = ("ViewsTestCase",)
 class ViewsTestCase(TestCase):
     urls = "threadedcomments.tests.threadedcomments_urls"
 
-    def setUp(self):
-        super().setUp()
-        from django.conf import settings
-        settings.SECRET_KEY = 'dummy-key-for-tests'
-
     def test_freecomment_create(self):
 
         topic = Person.objects.create(name="Test2")

--- a/threadedcomments/tests/views_tests.py
+++ b/threadedcomments/tests/views_tests.py
@@ -23,6 +23,11 @@ __all__ = ("ViewsTestCase",)
 class ViewsTestCase(TestCase):
     urls = "threadedcomments.tests.threadedcomments_urls"
 
+    def setUp(self):
+        super().setUp()
+        from django.conf import settings
+        settings.SECRET_KEY = 'dummy-key-for-tests'
+
     def test_freecomment_create(self):
 
         topic = Person.objects.create(name="Test2")

--- a/threadedcomments/urls.py
+++ b/threadedcomments/urls.py
@@ -1,29 +1,29 @@
-from django.conf.urls import url
+from django.urls import re_path
 from threadedcomments.models import FreeThreadedComment
 from threadedcomments import views
 
 free = {'model': FreeThreadedComment}
 
-urlpatterns = (
+urlpatterns = [
     ### Comments ###
-    url(r'^comment/(?P<content_type>\d+)/(?P<object_id>\d+)/$', views.comment, name="tc_comment"),
-    url(r'^comment/(?P<content_type>\d+)/(?P<object_id>\d+)/(?P<parent_id>\d+)/$', views.comment, name="tc_comment_parent"),
-    url(r'^comment/(?P<object_id>\d+)/delete/$', views.comment_delete, name="tc_comment_delete"),
-    url(r'^comment/(?P<edit_id>\d+)/edit/$', views.comment, name="tc_comment_edit"),
+    re_path(r'^comment/(?P<content_type>\d+)/(?P<object_id>\d+)/$', views.comment, name="tc_comment"),
+    re_path(r'^comment/(?P<content_type>\d+)/(?P<object_id>\d+)/(?P<parent_id>\d+)/$', views.comment, name="tc_comment_parent"),
+    re_path(r'^comment/(?P<object_id>\d+)/delete/$', views.comment_delete, name="tc_comment_delete"),
+    re_path(r'^comment/(?P<edit_id>\d+)/edit/$', views.comment, name="tc_comment_edit"),
 
     ### Comments (AJAX) ###
-    url(r'^comment/(?P<content_type>\d+)/(?P<object_id>\d+)/(?P<ajax>json|xml)/$', views.comment, name="tc_comment_ajax"),
-    url(r'^comment/(?P<content_type>\d+)/(?P<object_id>\d+)/(?P<parent_id>\d+)/(?P<ajax>json|xml)/$', views.comment, name="tc_comment_parent_ajax"),
-    url(r'^comment/(?P<edit_id>\d+)/edit/(?P<ajax>json|xml)/$', views.comment, name="tc_comment_edit_ajax"),
+    re_path(r'^comment/(?P<content_type>\d+)/(?P<object_id>\d+)/(?P<ajax>json|xml)/$', views.comment, name="tc_comment_ajax"),
+    re_path(r'^comment/(?P<content_type>\d+)/(?P<object_id>\d+)/(?P<parent_id>\d+)/(?P<ajax>json|xml)/$', views.comment, name="tc_comment_parent_ajax"),
+    re_path(r'^comment/(?P<edit_id>\d+)/edit/(?P<ajax>json|xml)/$', views.comment, name="tc_comment_edit_ajax"),
 
     ### Free Comments ###
-    url(r'^freecomment/(?P<content_type>\d+)/(?P<object_id>\d+)/$', views.free_comment, name="tc_free_comment"),
-    url(r'^freecomment/(?P<content_type>\d+)/(?P<object_id>\d+)/(?P<parent_id>\d+)/$', views.free_comment, name="tc_free_comment_parent"),
-    url(r'^freecomment/(?P<object_id>\d+)/delete/$', views.comment_delete, free, name="tc_free_comment_delete"),
-    url(r'^freecomment/(?P<edit_id>\d+)/edit/$', views.free_comment, name="tc_free_comment_edit"),
+    re_path(r'^freecomment/(?P<content_type>\d+)/(?P<object_id>\d+)/$', views.free_comment, name="tc_free_comment"),
+    re_path(r'^freecomment/(?P<content_type>\d+)/(?P<object_id>\d+)/(?P<parent_id>\d+)/$', views.free_comment, name="tc_free_comment_parent"),
+    re_path(r'^freecomment/(?P<object_id>\d+)/delete/$', views.comment_delete, free, name="tc_free_comment_delete"),
+    re_path(r'^freecomment/(?P<edit_id>\d+)/edit/$', views.free_comment, name="tc_free_comment_edit"),
 
     ### Free Comments (AJAX) ###
-    url(r'^freecomment/(?P<content_type>\d+)/(?P<object_id>\d+)/(?P<ajax>json|xml)/$', views.free_comment, name="tc_free_comment_ajax"),
-    url(r'^freecomment/(?P<content_type>\d+)/(?P<object_id>\d+)/(?P<parent_id>\d+)/(?P<ajax>json|xml)/$', views.free_comment, name="tc_free_comment_parent_ajax"),
-    url(r'^freecomment/(?P<edit_id>\d+)/edit/(?P<ajax>json|xml)/$', views.free_comment, name="tc_free_comment_edit_ajax"),
-)
+    re_path(r'^freecomment/(?P<content_type>\d+)/(?P<object_id>\d+)/(?P<ajax>json|xml)/$', views.free_comment, name="tc_free_comment_ajax"),
+    re_path(r'^freecomment/(?P<content_type>\d+)/(?P<object_id>\d+)/(?P<parent_id>\d+)/(?P<ajax>json|xml)/$', views.free_comment, name="tc_free_comment_parent_ajax"),
+    re_path(r'^freecomment/(?P<edit_id>\d+)/edit/(?P<ajax>json|xml)/$', views.free_comment, name="tc_free_comment_edit_ajax"),
+]

--- a/threadedcomments/utils.py
+++ b/threadedcomments/utils.py
@@ -5,13 +5,13 @@ import django
 from django.core.serializers import serialize
 from django.http import HttpResponse
 from django.utils.functional import Promise
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 
 class LazyEncoder(simplejson.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, Promise):
-            return force_text(obj)
+            return force_str(obj)
         return obj
 
 

--- a/threadedcomments/views.py
+++ b/threadedcomments/views.py
@@ -4,7 +4,6 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib import messages
 from django.shortcuts import get_object_or_404, render
 from django.template import Context, Template
-from urllib.parse import quote
 from django.conf import settings
 from threadedcomments.forms import FreeThreadedCommentForm, ThreadedCommentForm
 from threadedcomments.models import (
@@ -13,6 +12,7 @@ from threadedcomments.models import (
     DEFAULT_MAX_COMMENT_LENGTH,
 )
 from threadedcomments.utils import JSONResponse, XMLResponse
+from urllib.parse import quote
 
 
 def _adjust_max_comment_length(form, field_name='comment'):

--- a/threadedcomments/views.py
+++ b/threadedcomments/views.py
@@ -4,7 +4,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib import messages
 from django.shortcuts import get_object_or_404, render
 from django.template import Context, Template
-from django.utils.http import urlquote
+from urllib.parse import quote
 from django.conf import settings
 from threadedcomments.forms import FreeThreadedCommentForm, ThreadedCommentForm
 from threadedcomments.models import (
@@ -228,7 +228,7 @@ def comment_delete(
     tc = get_object_or_404(model, id=int(object_id))
     if not permission_callback(tc, request.user):
         login_url = settings.LOGIN_URL
-        current_url = urlquote(request.get_full_path())
+        current_url = quote(request.get_full_path())
         return HttpResponseRedirect("%s?next=%s" % (login_url, current_url))
     if request.method == "POST":
         tc.delete()

--- a/tox.ini
+++ b/tox.ini
@@ -5,13 +5,18 @@
 
 [tox]
 envlist =
-	py{27,37}-django1.11
 	py37-django2.2
+    py{38,39}-django{30,31,32,40,41,42}
 
 [testenv]
 commands = {envpython} run_tests.py
 deps =
 	django_nose
 	six
-	django1.11: Django>=1.11, <1.12
-	django2.2: Django>=2.2, <2.3
+    django2.2: Django>=2.2, <2.3
+    django30: Django>=3.0, <3.1
+    django31: Django>=3.1, <3.2
+    django32: Django>=3.2, <3.3
+    django40: Django>=4.0, <4.1
+    django41: Django>=4.1, <4.2
+    django42: Django>=4.2, <4.3


### PR DESCRIPTION
## Unit Test Updates
- [x] Update unit tests so that they are functional, and no longer attempting to utilize the Markdown features which are not being utilized in the application.
- [x] Fix the SECRET_KEY testing error that occurs for Django 3.2.


## Compatibility fixes for Django 4.2

## Django 4.0.10
* [Django 4.0 deprecations](https://docs.djangoproject.com/en/5.0/internals/deprecation/#deprecation-removed-in-4-0):
* See the [Django 3.0 release notes](https://docs.djangoproject.com/en/5.0/releases/3.0/#deprecated-features-3-0) for more details on these changes.

- [x] **django.utils.encoding.force_text()** and **smart_text()** will be removed.  The aliases are  force_str() and smart_str().
- [x] **django.utils.http.urlquote()**, **urlquote_plus()**, **urlunquote()**, and **urlunquote_plus()** will be removed.
- [x] **django.utils.translation.ugettext()**, **ugettext_lazy()**, **ugettext_noop()**, **ungettext()**, and **ungettext_lazy()** will be removed.
- [x] **django.views.i18n.set_language()** will no longer set the user language in **request.session** (key **django.utils.translation.LANGUAGE_SESSION_KEY**). 
- [x] **alias=None** will be required in the signature of **django.db.models.Expression.get_group_by_cols()** subclasses.
- [x] **django.utils.text.unescape_entities()** will be removed.
- [x] **django.utils.http.is_safe_url()** will be removed.

* See the [Django 3.1 release notes](https://docs.djangoproject.com/en/5.0/releases/3.1/#deprecated-features-3-1) for more details on these changes.
- [x] **The PASSWORD_RESET_TIMEOUT_DAYS** setting will be removed.
- [x] The undocumented usage of the **isnull** lookup with non-boolean values as the right-hand side will no longer be allowed.
- [x] The **django.db.models.query_utils.InvalidQuery** exception class will be removed.
- [x] The **django-admin.py** entry point will be removed.
- [x] Support for the pre-Django 3.1 encoding format of cookies values used by **django.contrib.messages.storage.cookie.CookieStorage** will be removed.
- [x] The **providing_args** argument for **django.dispatch.Signal** will be removed.
- [x] The **length** argument for **django.utils.crypto.get_random_string()** will be required.
- [x] The model **NullBooleanField** will be removed. A stub field will remain for compatibility with historical migrations. 
- [x] The model **django.contrib.postgres.fields.JSONField** will be removed. A stub field will remain for compatibility with historical migrations.
- [x] **django.contrib.postgres.forms.JSONField**, **django.contrib.postgres.fields.jsonb.KeyTransform**, and **django.contrib.postgres.fields.jsonb.KeyTextTransform** will be removed.
- [x] The **DEFAULT_HASHING_ALGORITHM** transitional setting will be removed.
- [x] Support for passing raw column aliases to **QuerySet.order_by()** will be removed.
- [x] **django.conf.urls.url()** will be removed.  It's an alias of **django.urls.re_path()**.
- [x] The **get_response** argument for **django.utils.deprecation.MiddlewareMixin.__init__()** will be required and won’t accept **None**.
- [x] The **list** message for **ModelMultipleChoiceField** will be removed.
- [x] The **HttpRequest.is_ajax()** method will be removed.
- [x] The **{% ifequal %}** and **{% ifnotequal %}** template tags will be removed.

### pre-Django 3.1 SHA-1
- [x] Support for the pre-Django 3.1 password reset tokens in the admin site (that use the SHA-1 hashing algorithm) will be removed.
- [x] Support for the pre-Django 3.1 encoding format of sessions will be removed.
- [x] Support for the pre-Django 3.1 **django.core.signing.Signer** signatures (encoded with the SHA-1 algorithm) will be removed.
- [x] Support for the pre-Django 3.1 **django.core.signing.dumps()** signatures (encoded with the SHA-1 algorithm) in **django.core.signing.loads()** will be removed.
- [x] Support for the pre-Django 3.1 user sessions (that use the SHA-1 algorithm) will be removed.

## Django 4.1.13
See the [Django 3.2 release notes](https://docs.djangoproject.com/en/5.0/releases/3.2/#deprecated-features-3-2) for more details on these changes.

- [x] Support for assigning objects which don’t support creating deep copies with **copy.deepcopy()** to class attributes in **TestCase.setUpTestData()** will be removed.
- [x] The **whitelist** argument and **domain_whitelist** attribute of **django.core.validators.EmailValidator** will be removed.
- [x] **TransactionTestCase.assertQuerysetEqual()** will no longer automatically call **repr()** on a queryset when compared to string values.
- [x] Support for the pre-Django 3.2 format of messages used by **django.contrib.messages.storage.cookie.CookieStorage** will be removed.
- [x] **BaseCommand.requires_system_checks** won’t support boolean values. Use '__all__' instead of True, and [] (an empty list) instead of False.
- [x] **django.core.cache.backends.memcached.MemcachedCache** will be removed.
- [x] The **default_app_config** module variable will be removed. 
